### PR TITLE
킥보드 등록 페이지 지도 구현

### DIFF
--- a/KickboardApp/KickboardApp/Common/Extensions/Double+.swift
+++ b/KickboardApp/KickboardApp/Common/Extensions/Double+.swift
@@ -1,0 +1,14 @@
+//
+//  Double+.swift
+//  KickboardApp
+//
+//  Created by 이수현 on 4/29/25.
+//
+
+import Foundation
+
+extension Double {
+    func formatted(toDecimalDigits digits: Int) -> String {
+        return String(format: "%.\(digits)f", self)
+    }
+}

--- a/KickboardApp/KickboardApp/DataLayer/CoreData/Base/CoreData.xcdatamodeld/CoreData.xcdatamodel/contents
+++ b/KickboardApp/KickboardApp/DataLayer/CoreData/Base/CoreData.xcdatamodeld/CoreData.xcdatamodel/contents
@@ -14,5 +14,23 @@
         <attribute name="latitude" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="longitude" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <relationship name="brand" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="BrandEntity" inverseName="kickboard" inverseEntity="BrandEntity"/>
+        <relationship name="rideHistory" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="RideHistoryEntity" inverseName="kickboard" inverseEntity="RideHistoryEntity"/>
+        <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserEntity" inverseName="kickboard" inverseEntity="UserEntity"/>
+    </entity>
+    <entity name="RideHistoryEntity" representedClassName="RideHistoryEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="date" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="endTime" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="price" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="startTime" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="kickboard" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="KickboardEntity" inverseName="rideHistory" inverseEntity="KickboardEntity"/>
+        <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserEntity" inverseName="rideHistory" inverseEntity="UserEntity"/>
+    </entity>
+    <entity name="UserEntity" representedClassName="UserEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="id" attributeType="String"/>
+        <attribute name="nickname" attributeType="String"/>
+        <attribute name="password" attributeType="String"/>
+        <relationship name="kickboard" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="KickboardEntity" inverseName="user" inverseEntity="KickboardEntity"/>
+        <relationship name="rideHistory" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="RideHistoryEntity" inverseName="user" inverseEntity="RideHistoryEntity"/>
     </entity>
 </model>

--- a/KickboardApp/KickboardApp/PresentationLayer/Register/RegisterViewController.swift
+++ b/KickboardApp/KickboardApp/PresentationLayer/Register/RegisterViewController.swift
@@ -6,10 +6,10 @@
 //
 
 import UIKit
+import NMapsMap
 
 final class RegisterViewController: UIViewController {
     private let registerView = RegisterView()
-
 
     override func loadView() {
         super.loadView()
@@ -24,11 +24,19 @@ final class RegisterViewController: UIViewController {
 
     private func setProtocol() {
         registerView.setKickboardSettingViewDelegate(self)
+        registerView.setCameraDelegate(self)
     }
 }
 
 extension RegisterViewController: KickboardSettingViewDelegate {
     func didTapRegisterButton(latitude: Double, longitude: Double, brand: Brand, battery: Int) {
         print("latitude: \(latitude), longitude: \(longitude), brand: \(brand), battery: \(battery)")
+    }
+}
+
+extension RegisterViewController: NMFMapViewCameraDelegate {
+    func mapViewCameraIdle(_ mapView: NMFMapView) {
+        let location = mapView.cameraPosition.target
+        registerView.configure(location: location)
     }
 }

--- a/KickboardApp/KickboardApp/PresentationLayer/Register/Subviews/KickboardSettingView.swift
+++ b/KickboardApp/KickboardApp/PresentationLayer/Register/Subviews/KickboardSettingView.swift
@@ -8,6 +8,7 @@
 import UIKit
 import Then
 import SnapKit
+import NMapsMap
 
 protocol KickboardSettingViewDelegate: AnyObject {
     func didTapRegisterButton(latitude: Double, longitude: Double, brand: Brand, battery: Int)
@@ -57,6 +58,11 @@ final class KickboardSettingView: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    func configure(location: NMGLatLng) {
+        latitudeValueLabel.text = location.lat.formatted(toDecimalDigits: 4)
+        longitudeValueLabel.text = location.lng.formatted(toDecimalDigits: 4)
+    }
 }
 
 private extension KickboardSettingView {
@@ -105,9 +111,10 @@ private extension KickboardSettingView {
         }
 
         latitudeValueLabel.do {
-            $0.backgroundColor = .gray2
+            $0.backgroundColor = .gray4
             $0.textAlignment = .center
             $0.text = "위도 값"
+            $0.textColor = .black2
             $0.font = .font(.pretendardMedium, ofSize: 14)
         }
 
@@ -124,9 +131,10 @@ private extension KickboardSettingView {
         }
 
         longitudeValueLabel.do {
-            $0.backgroundColor = .gray2
+            $0.backgroundColor = .gray4
             $0.textAlignment = .center
             $0.text = "경도 값"
+            $0.textColor = .black2
             $0.font = .font(.pretendardMedium, ofSize: 14)
         }
 

--- a/KickboardApp/KickboardApp/PresentationLayer/Register/Subviews/RegisterMapPinView.swift
+++ b/KickboardApp/KickboardApp/PresentationLayer/Register/Subviews/RegisterMapPinView.swift
@@ -1,0 +1,100 @@
+//
+//  RegisterMapPinView.swift
+//  KickboardApp
+//
+//  Created by 이수현 on 4/29/25.
+//
+
+import UIKit
+
+final class RegisterMapPinView: UIView {
+    private let containerView = UIView()
+    private let titleLabel = UILabel()
+    private let subTitleLabel = UILabel()
+    private let tailView = UIView()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    @available(*, unavailable, message: "storyboard is not supported.")
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented.")
+    }
+
+    private func addTailShape() {
+        let path = UIBezierPath()
+        path.move(to: CGPoint(x: 0, y: 0))
+        path.addLine(to: CGPoint(x: 15, y: 0))
+        path.addLine(to: CGPoint(x: 7.5, y: 15))
+        path.close()
+
+        let shapeLayer = CAShapeLayer()
+        shapeLayer.path = path.cgPath
+        shapeLayer.fillColor = UIColor.black2?.cgColor
+
+        tailView.layer.insertSublayer(shapeLayer, at: 0)
+    }
+}
+private extension RegisterMapPinView {
+
+    func configure() {
+        setLayout()
+        setHierarchy()
+        setConstraints()
+    }
+
+    func setLayout() {
+        containerView.do {
+            $0.backgroundColor = .black2
+            $0.layer.cornerRadius = 8
+        }
+
+        titleLabel.do {
+            $0.text = "등록 위치"
+            $0.textColor = .primary
+            $0.font = .font(.pretendardBold, ofSize: 14)
+            $0.textAlignment = .center
+        }
+
+        subTitleLabel.do {
+            $0.text = "킥보드의 위치를 설정해주세요"
+            $0.textColor = .white
+            $0.font = .font(.pretendardRegular, ofSize: 12)
+            $0.textAlignment = .center
+        }
+    }
+
+    func setHierarchy() {
+        self.addSubViews(containerView, tailView)
+        containerView.addSubViews(titleLabel, subTitleLabel)
+    }
+
+    func setConstraints() {
+        containerView.snp.makeConstraints { make in
+            make.top.directionalHorizontalEdges.equalToSuperview()
+        }
+
+        titleLabel.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(12)
+            make.directionalHorizontalEdges.equalToSuperview().inset(12)
+        }
+
+        subTitleLabel.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom)
+            make.directionalHorizontalEdges.bottom.equalToSuperview().inset(12)
+        }
+
+        tailView.snp.makeConstraints { make in
+            make.top.equalTo(containerView.snp.bottom)
+            make.width.equalTo(15)
+            make.height.equalTo(15)
+            make.centerX.equalToSuperview()
+            make.bottom.equalToSuperview()
+        }
+
+        addTailShape()
+    }
+}
+

--- a/KickboardApp/KickboardApp/PresentationLayer/Register/Subviews/RegisterView.swift
+++ b/KickboardApp/KickboardApp/PresentationLayer/Register/Subviews/RegisterView.swift
@@ -6,12 +6,13 @@
 //
 
 import UIKit
+import NMapsMap
 
 final class RegisterView: UIView {
 
     private let titleView = RegisterTitleView()
-    private let mapView = UIView()
-
+    private let mapView = NMFMapView()
+    private let mapPinView = RegisterMapPinView()
     private let settingView = KickboardSettingView()
 
 
@@ -37,7 +38,7 @@ private extension RegisterView {
     }
 
     func setHierarchy() {
-        addSubViews(titleView, mapView, settingView)
+        addSubViews(titleView, mapView, mapPinView, settingView)
     }
 
     func setStyle() {
@@ -63,8 +64,12 @@ private extension RegisterView {
 
         mapView.snp.makeConstraints { make in
             make.top.equalTo(titleView.snp.bottom).offset(12)
-            make.bottom.equalTo(safeAreaLayoutGuide)
+            make.bottom.equalTo(settingView.snp.top)
             make.directionalHorizontalEdges.equalToSuperview()
+        }
+
+        mapPinView.snp.makeConstraints { make in
+            make.center.equalTo(mapView)
         }
 
         settingView.snp.makeConstraints { make in

--- a/KickboardApp/KickboardApp/PresentationLayer/Register/Subviews/RegisterView.swift
+++ b/KickboardApp/KickboardApp/PresentationLayer/Register/Subviews/RegisterView.swift
@@ -15,7 +15,6 @@ final class RegisterView: UIView {
     private let mapPinView = RegisterMapPinView()
     private let settingView = KickboardSettingView()
 
-
     init() {
         super.init(frame: .zero)
         configure()
@@ -27,6 +26,14 @@ final class RegisterView: UIView {
 
     func setKickboardSettingViewDelegate(_ delegate: KickboardSettingViewDelegate) {
         settingView.delegate = delegate
+    }
+
+    func setCameraDelegate(_ delegate: NMFMapViewCameraDelegate) {
+        mapView.addCameraDelegate(delegate: delegate)
+    }
+
+    func configure(location: NMGLatLng) {
+        settingView.configure(location: location)
     }
 }
 


### PR DESCRIPTION
## 🔗 관련 이슈
closed #16 

## 📌 PR 요약
킥보드 등록 페이지 지도 구현

## 🔖 작업 내용
1. 킥보드 등록 페이지 지도 구현
2. CoreData 엔티티 구현


## 🎆 스크린샷(선택)
<table>
  <tr>
    <td colspan="1" style="text-align: center; font-weight: bold;">
16 Pro
    </td>
    <td colspan="1" style="text-align: center; font-weight: bold;">
SE
    </td>
  </tr>
  <tr>
    <td style="text-align: center;"><img src="https://github.com/user-attachments/assets/967e6300-f6da-4622-8ad4-22e4992f54e6" width="300"/></td>
    <td style="text-align: center;"><img src="https://github.com/user-attachments/assets/351e7803-6433-4a1c-a9be-73b14a72f77e" width="300"/></td>
  </tr>
</table>

## 💡 추가 참고 사항
코어 데이터 엔티티가 수정되어서 기존 CoreData 기능 파일 수정이 필요합니다
