### PR TITLE
주변 마커 생성 및 마커 탭 시 킥보드 정보 바텀시트 구현

### DIFF
--- a/KickboardApp/KickboardApp/PresentationLayer/Home/View/HomeBottomSheetView.swift
+++ b/KickboardApp/KickboardApp/PresentationLayer/Home/View/HomeBottomSheetView.swift
@@ -30,11 +30,10 @@ final class HomeBottomSheetView: UIView {
     func configure(with kickboard: Kickboard) {
         self.kbBrandLabel.text = kickboard.brand.title
         self.kbModelLabel.text = String(kickboard.id.uuidString.prefix(8))
-        self.kbCommentLabel.attributedText = makeComment(distance: Int(kickboard.brand.distancePerBatteryUnit))
+        self.kbCommentLabel.attributedText = makeComment(distance: kickboard.brand.distancePerBatteryUnit)
         self.kbFeePerMinuteLabel.text = "분당 \(kickboard.brand.pricePerMinute)원"
         self.kbImageView.image = UIImage(named: "\(kickboard.brand.imageName)")
-//        self.kbRemainedBatteryView.configure(with: kickboard.battery)
-        self.kbRemainedBatteryView.configure(with: 75)
+        self.kbRemainedBatteryView.configure(with: kickboard.battery)
     }
 }
 
@@ -141,7 +140,7 @@ private extension HomeBottomSheetView {
 }
 
 extension HomeBottomSheetView {
-    private func makeComment(distance: Int) -> NSAttributedString {
+    private func makeComment(distance: Double) -> NSAttributedString {
         let fullText = "약 \(distance)km 주행할 수 있어요!"
         let attributedString = NSMutableAttributedString(string: fullText)
 

--- a/KickboardApp/KickboardApp/PresentationLayer/Home/View/HomeView.swift
+++ b/KickboardApp/KickboardApp/PresentationLayer/Home/View/HomeView.swift
@@ -9,11 +9,12 @@ import UIKit
 import NMapsMap
 
 protocol HomeViewDelegate: AnyObject {
-    func didTapMarker()
+    func didTapMarker(with kickboard: Kickboard)
 }
 
 final class HomeView: UIView {
     weak var delegate: HomeViewDelegate?
+    private var markers: [NMFMarker] = []
 
     private let searchTextField = UITextField()
     private let naverMapView = NMFNaverMapView()
@@ -66,7 +67,6 @@ private extension HomeView {
             $0.rightViewMode = .always
             $0.rightView = rightButton
 
-            rightButton.addTarget(self, action: #selector(didTapMarker), for: .touchUpInside)
         }
     }
 
@@ -89,10 +89,6 @@ private extension HomeView {
     func setAction() {
 
     }
-
-    @objc private func didTapMarker() {
-        delegate?.didTapMarker()
-    }
 }
 
 extension HomeView {
@@ -106,5 +102,24 @@ extension HomeView {
         
         naverMapView.mapView.moveCamera(cameraUpdate)
     }
-}
 
+    func updateKickboardMarkers(with: [Kickboard]) {
+        markers.removeAll()
+
+        with.forEach { kickboard in
+            let marker = NMFMarker()
+            marker.position = NMGLatLng(lat: kickboard.latitude, lng: kickboard.longitude)
+            marker.mapView = naverMapView.mapView
+            marker.width = 20
+            marker.height = 35
+            marker.touchHandler = { [weak self] (overlay: NMFOverlay) -> Bool in
+                guard let self else { return false }
+                
+                self.delegate?.didTapMarker(with: kickboard)
+
+                return true
+            }
+            markers.append(marker)
+        }
+    }
+}

--- a/KickboardApp/KickboardApp/PresentationLayer/Home/View/HomeView.swift
+++ b/KickboardApp/KickboardApp/PresentationLayer/Home/View/HomeView.swift
@@ -16,7 +16,7 @@ final class HomeView: UIView {
     weak var delegate: HomeViewDelegate?
 
     private let searchTextField = UITextField()
-    private let mapView = NMFMapView()
+    private let naverMapView = NMFNaverMapView()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -71,11 +71,11 @@ private extension HomeView {
     }
 
     func setHierarchy() {
-        addSubViews(mapView, searchTextField)
+        addSubViews(naverMapView, searchTextField)
     }
 
     func setConstraints() {
-        mapView.snp.makeConstraints {
+        naverMapView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
 
@@ -96,8 +96,15 @@ private extension HomeView {
 }
 
 extension HomeView {
-    func moveCamera(to update: NMFCameraUpdate) {
-        mapView.moveCamera(update)
+    func moveCamera(to update: NMGLatLng) {
+        let cameraUpdate = NMFCameraUpdate(scrollTo: update)
+        cameraUpdate.animation = .easeIn
+
+        let locationOverlay = naverMapView.mapView.locationOverlay
+        locationOverlay.location = update
+        locationOverlay.hidden = false
+        
+        naverMapView.mapView.moveCamera(cameraUpdate)
     }
 }
 

--- a/KickboardApp/KickboardApp/PresentationLayer/Home/ViewController/HomeBottomSheetViewController.swift
+++ b/KickboardApp/KickboardApp/PresentationLayer/Home/ViewController/HomeBottomSheetViewController.swift
@@ -7,9 +7,10 @@
 
 import UIKit
 
-class HomeBottomSheetViewController: UIViewController {
-
+final class HomeBottomSheetViewController: UIViewController {
     private let homeBottomSheetView = HomeBottomSheetView()
+
+    var kickboard: Kickboard?
 
     override func loadView() {
         view = homeBottomSheetView
@@ -20,7 +21,7 @@ class HomeBottomSheetViewController: UIViewController {
 
         homeBottomSheetView
             .configure(
-                with: Kickboard(
+                with: kickboard ?? Kickboard(
                     id: UUID(),
                     latitude: 31.123412,
                     longitude: 125.123412,
@@ -35,5 +36,5 @@ class HomeBottomSheetViewController: UIViewController {
                 )
             )
     }
-    
+
 }

--- a/KickboardApp/KickboardApp/PresentationLayer/Home/ViewController/HomeViewController.swift
+++ b/KickboardApp/KickboardApp/PresentationLayer/Home/ViewController/HomeViewController.swift
@@ -85,11 +85,10 @@ private extension HomeViewController {
     }
 
     func updateToCurrentPosition() {
-        let cameraUpdate = NMFCameraUpdate(scrollTo: NMGLatLng(
+        let cameraUpdate = NMGLatLng(
             lat: locationManager.location?.coordinate.latitude ?? 0,
             lng: locationManager.location?.coordinate.longitude ?? 0
-        ))
-        cameraUpdate.animation = .easeIn
+        )
         DispatchQueue.main.async {
             self.homeView.moveCamera(to: cameraUpdate)
         }

--- a/KickboardApp/KickboardApp/PresentationLayer/Home/ViewController/HomeViewController.swift
+++ b/KickboardApp/KickboardApp/PresentationLayer/Home/ViewController/HomeViewController.swift
@@ -10,8 +10,9 @@ import NMapsMap
 import CoreLocation
 import FittedSheets
 
-class HomeViewController: UIViewController {
+final class HomeViewController: UIViewController {
     private let homeView = HomeView()
+    private let homeViewModel: HomeViewModelProtocol = HomeViewModel()
     let locationManager = CLLocationManager()
 
     override func loadView() {
@@ -23,6 +24,8 @@ class HomeViewController: UIViewController {
 
         locationManager.delegate = self
         homeView.delegate = self
+
+        homeViewModel.generateMockKickboards()
     }
 
 
@@ -100,7 +103,11 @@ private extension HomeViewController {
 
 extension HomeViewController: CLLocationManagerDelegate {
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-
+        guard let currentLocation = locations.last else { print("마지막 위치 정보 없음"); return }
+        let filteredKickboards = homeViewModel.nearbyKickboards(from: currentLocation, within: 300)
+        DispatchQueue.main.async {
+            self.homeView.updateKickboardMarkers(with: filteredKickboards)
+        }
     }
 
 
@@ -113,9 +120,10 @@ extension HomeViewController: CLLocationManagerDelegate {
 }
 
 extension HomeViewController: HomeViewDelegate {
-    func didTapMarker() {
-        print("didTapKickboard")
+    func didTapMarker(with kickboard: Kickboard) {
         let vc = HomeBottomSheetViewController()
+        vc.kickboard = kickboard
+
         var options = SheetOptions()
         // 라이브러리 기본 옵션을 취소하는 설정들
         options.shrinkPresentingViewController = false

--- a/KickboardApp/KickboardApp/PresentationLayer/Home/ViewModel/HomeViewModel.swift
+++ b/KickboardApp/KickboardApp/PresentationLayer/Home/ViewModel/HomeViewModel.swift
@@ -1,0 +1,85 @@
+//
+//  HomeViewModel.swift
+//  KickboardApp
+//
+//  Created by 송규섭 on 4/30/25.
+//
+
+import Foundation
+import CoreLocation
+
+protocol HomeViewModelProtocol: AnyObject {
+    var mockKickboards: [Kickboard] { get set }
+
+    func generateMockKickboards()
+    func nearbyKickboards(from location: CLLocation, within meters: Double) -> [Kickboard]
+}
+
+final class HomeViewModel: HomeViewModelProtocol {
+
+    var mockKickboards: [Kickboard] = []
+
+    func generateMockKickboards() {
+        mockKickboards = [
+            Kickboard(
+                id: UUID(),
+                latitude: 34.499621,
+                longitude: 126.531188,
+                battery: 34,
+                isAvailable: true,
+                brand: Brand(
+                    title: "씽씽",
+                    imageName: "ssingSsing",
+                    distancePerBatteryUnit: 2,
+                    pricePerMinute: 190
+                )
+            ),
+            Kickboard(
+                id: UUID(),
+                latitude: 33.499221,
+                longitude: 126.531688,
+                battery: 86,
+                isAvailable: true,
+                brand: Brand(
+                    title: "빔",
+                    imageName: "beam",
+                    distancePerBatteryUnit: 3,
+                    pricePerMinute: 170
+                )
+            ),
+            Kickboard(
+                id: UUID(),
+                latitude: 33.498921,
+                longitude: 126.530188,
+                battery: 68,
+                isAvailable: true,
+                brand: Brand(
+                    title: "킥",
+                    imageName: "kick",
+                    distancePerBatteryUnit: 2.5,
+                    pricePerMinute: 180
+                )
+            ),
+            Kickboard(
+                id: UUID(),
+                latitude: 33.500321,
+                longitude: 126.532288,
+                battery: 44,
+                isAvailable: true,
+                brand: Brand(
+                    title: "씽씽",
+                    imageName: "ssingSsing",
+                    distancePerBatteryUnit: 2,
+                    pricePerMinute: 190
+                )
+            )
+        ]
+    }
+
+    func nearbyKickboards(from location: CLLocation, within meters: Double) -> [Kickboard] {
+        return mockKickboards.filter { kickboard in
+            let kickboardLocation = CLLocation(latitude: kickboard.latitude, longitude: kickboard.longitude)
+            return location.distance(from: kickboardLocation) <= meters
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
closed #26 
## 📌 PR 요약
내 주변에 등록된 킥보드를 기준으로 마커를 띄우는 작업 진행
## 🔖 작업 내용
- [x] HomeViewModel 내 목데이터 활용하도록 구현
- [x] 목데이터에서 근처 데이터를 넘겨 마커 생성 및 위치하도록 구현
- [x] 마커 탭 시 바텀시트 올라오도록 구현
## 🎆 스크린샷(선택)
<img width="559" alt="image" src="https://github.com/user-attachments/assets/8d4a461b-8309-42e3-909c-a3c741bb7806" />

## 💡 추가 참고 사항
